### PR TITLE
KV-HCVault-SavingIssues

### DIFF
--- a/hashicorp-vault-orchestrator/HcvKeyValueClient.cs
+++ b/hashicorp-vault-orchestrator/HcvKeyValueClient.cs
@@ -38,9 +38,6 @@ namespace Keyfactor.Extensions.Orchestrator.HashicorpVault
 
         //private VaultClientSettings clientSettings { get; set; }
 
-        private static readonly string privKeyStart = "-----BEGIN RSA PRIVATE KEY-----\n";
-        private static readonly string privKeyEnd = "\n-----END RSA PRIVATE KEY-----";
-
         public HcvKeyValueClient(string vaultToken, string serverUrl, string mountPoint, string storePath)
         {
             // Initialize one of the several auth methods.
@@ -193,7 +190,6 @@ namespace Keyfactor.Extensions.Orchestrator.HashicorpVault
 
             try
             {
-                privateKeyString = privateKeyString.Replace(privKeyStart, "").Replace(privKeyEnd, "");
                 certDict.Add("PRIVATE_KEY", privateKeyString);
                 certDict.Add("PUBLIC_KEY", pubCertPem);
             }
@@ -278,9 +274,15 @@ namespace Keyfactor.Extensions.Orchestrator.HashicorpVault
 
             return certs;
         }
+        private static Func<string, string> Pemify = base64Cert =>
+        {
+            string FormatBase64(string ss) =>
+                ss.Length <= 64 ? ss : ss.Substring(0, 64) + "\n" + FormatBase64(ss.Substring(64));
 
+            string header = "-----BEGIN CERTIFICATE-----\n";
+            string footer = "\n-----END CERTIFICATE-----";
 
-        private static Func<string, string> Pemify = ss =>
-            ss.Length <= 64 ? ss : ss.Substring(0, 64) + "\n" + Pemify(ss.Substring(64));
+            return header + FormatBase64(base64Cert) + footer;
+        };
     }
 }

--- a/hashicorp-vault-orchestrator/HcvKeyValueClient.cs
+++ b/hashicorp-vault-orchestrator/HcvKeyValueClient.cs
@@ -196,7 +196,6 @@ namespace Keyfactor.Extensions.Orchestrator.HashicorpVault
                 privateKeyString = privateKeyString.Replace(privKeyStart, "").Replace(privKeyEnd, "");
                 certDict.Add("PRIVATE_KEY", privateKeyString);
                 certDict.Add("PUBLIC_KEY", pubCertPem);
-                certDict.Add("KEY_SECRET", pfxPassword);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
@joevanwanzeeleKF 

This branch addresses two of the issues identified with the the **kv-sub-path-support** branch:
-KEY_SECRET is an unnecessary value. (Extension is already saving PrivateKey-Unencrypted to HC-Vault by default. 
-PRIVATE_KEY & PUBLIC_KEY are being saved **without** normal PEM banners (-----BEGIN  ------END)