### PR TITLE
Adds toggle for recursive subfolder inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,10 @@ This integration was built on the .NET Core 3.1 target framework and are compati
 
 1. It is not necessary to use the Vault root token when creating a Certificate Store for HashicorpVault.  We recommend creating a token with policies that reflect the minimum permissions necessary to perform the intended operations.
 
-1. For the Key-Value secrets engine, the certificates are stored as an entry with 3 fields.  
+1. For the Key-Value secrets engine, the certificates are stored as an entry with 2 fields.  
 
 - `PUBLIC_KEY` - The certificate public key
 - `PRIVATE_KEY` - The certificate private key
-- `KEY_SECRET` - The certificate private key password
 
 ## Extension Configuration
 
@@ -121,6 +120,7 @@ This integration was built on the .NET Core 3.1 target framework and are compati
   - **MountPoint** - type: *string*
   - **VaultServerUrl** - type: *string*, *required*
   - **VaultToken** - type: *secret*, *required*
+  - **SubfolderInventory** - type: *bool* (By default, this is set to false. Not a required field)
 
 ![](images/store_type_fields.png)
 
@@ -144,6 +144,7 @@ In Keyfactor Command create a new Certificate Store that resembles the one below
   - If left blank, will default to "kv-v2".
 - **Vault Token** - This is the access token that will be used by the orchestrator for requests to Vault.
 - **Vault Server Url** - the full url and port of the Vault server instance
+- **Subfolder Inventory** - Set to 'True' if it is a requirement to inventory secrets at the subfolder/component level. The default, 'False' will inventory secrets stored at the root of the "Store Path", but will not look at secrets in subfolders.
 
 ### For the Keyfactor and PKI plugins
 
@@ -238,4 +239,3 @@ At this point you should be able to enroll a certificate and store it in Vault u
 ## Notes / Future Enhancements
 
 - For the Key-Value stores we operate on a single version of the Key Value secret (no versioning capabilities through the Orchesterator Extension / Keyfactor).
-

--- a/hashicorp-vault-orchestrator/Jobs/JobBase.cs
+++ b/hashicorp-vault-orchestrator/Jobs/JobBase.cs
@@ -21,6 +21,8 @@ namespace Keyfactor.Extensions.Orchestrator.HashicorpVault.Jobs
         public string SecretsEngine { get; set; } // "PKI", "Keyfactor", "Key Value"
 
         public string VaultServerUrl { get; set; }
+        
+        public bool SubfolderInventory { get; set; }
 
         public string MountPoint { get; set; } // the mount point of the KV secrets engine.  defaults to KV
 
@@ -69,12 +71,20 @@ namespace Keyfactor.Extensions.Orchestrator.HashicorpVault.Jobs
             VaultServerUrl = props["VaultServerUrl"];
             SecretsEngine = props["SecretsEngine"];
             MountPoint = props["MountPoint"] ?? null;
+            if (props["SubfolderInventory"] == null)
+            {
+                SubfolderInventory = false;
+            }
+            else
+            {
+                SubfolderInventory = props["SubfolderInventory"];
+            }
 
             var isPki = capability.Contains("HCVPKI");
 
             if (!isPki)
             {
-                VaultClient = new HcvKeyValueClient(VaultToken, VaultServerUrl, MountPoint, StorePath);
+                VaultClient = new HcvKeyValueClient(VaultToken, VaultServerUrl, MountPoint, StorePath, SubfolderInventory);
             }
             else
             {


### PR DESCRIPTION
Added the ability to do subfolder/component inventory. 

For example: 
If the targeted certstore path is: /keyfactor-certs/
Typical behavior will only pull secrets saved at the root. Like these:
/keyfactor-certs/certificate1
/keyfactor-certs/certificate2

It would not include (because of the subdirectory/component)
/keyfactor-certs/**application1**/certificate2

I've now added the ability to Recurse through the subdirectories. If the (certstore & certstore type) is configured with a SubfolderInventory (bool:true)

If this value is not configured, at the cert store or the cert store type it is just ignored, and the default behavior stays in place. 
