### PR TITLE
Adding InputValidation for KeyValue secrets

### DIFF
--- a/hashicorp-vault-orchestrator/HcvKeyValueClient.cs
+++ b/hashicorp-vault-orchestrator/HcvKeyValueClient.cs
@@ -118,8 +118,27 @@ namespace Keyfactor.Extensions.Orchestrator.HashicorpVault
 
             try
             {
-                string publicKey = certData["PUBLIC_KEY"]?.ToString() ?? null;
-                bool hasPrivateKey = certData["PRIVATE_KEY"] != null;
+                string publicKey;
+                bool hasPrivateKey;
+
+                //Validates if the "PUBLIC_KEY" and "PRIVATE_KEY" keys exist in certData
+                if (certData.TryGetValue("PUBLIC_KEY", out object publicKeyObj))
+                {
+                    publicKey = publicKeyObj?.ToString();
+                }
+                else
+                {
+                    publicKey = null;
+                }
+
+                if (certData.TryGetValue("PRIVATE_KEY", out object privateKeyObj))
+                {
+                    hasPrivateKey = true;
+                }
+                else
+                {
+                    hasPrivateKey = false;
+                }
 
                 var certs = new List<string>() { publicKey };
 

--- a/readme_source.md
+++ b/readme_source.md
@@ -41,6 +41,8 @@ This integration was built on the .NET Core 3.1 target framework and are compati
 - `PUBLIC_KEY` - The certificate public key
 - `PRIVATE_KEY` - The certificate private key
 
+**Note**: Key/Value secrets that do not include these keys (PUBLIC_KEY, and PRIVATE_KEY), will be ignored during inventory scans. 
+
 ## Extension Configuration
 
 ### On the Orchestrator Agent Machine


### PR DESCRIPTION
Ran into errors when a storePath contained secrets that were not in the correct format. If the secret did not contain the keys PUBLIC_KEY, and PRIVATE_KEY inventory jobs would stop and discontinue. (At the point it met the "unexpected" secret)

Code implemented here will ignore secrets that do not include the correct keys in the "secret".

Added a note in regards to this to the documentation.